### PR TITLE
FEATURE: config object format for directives to support merging CSP config split into different files

### DIFF
--- a/Classes/Command/CspConfigCommandController.php
+++ b/Classes/Command/CspConfigCommandController.php
@@ -31,7 +31,7 @@ class CspConfigCommandController extends CommandController
 
     /**
      * @Flow\InjectConfiguration(path="content-security-policy")
-     * @var string[][][]
+     * @var array<string, array<string, array<string|int, string|bool>>>
      */
     protected array $configuration;
 

--- a/Classes/Exceptions/DirectivesNormalizerException.php
+++ b/Classes/Exceptions/DirectivesNormalizerException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\ContentSecurityPolicy\Exceptions;
+
+use Neos\Flow\Exception;
+
+class DirectivesNormalizerException extends Exception
+{
+    public function __construct(string $reason)
+    {
+        parent::__construct(
+            "Invalid yaml config provided. {$reason} Please check your settings.",
+        );
+    }
+}

--- a/Classes/Factory/PolicyFactory.php
+++ b/Classes/Factory/PolicyFactory.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Flowpack\ContentSecurityPolicy\Factory;
 
+use Flowpack\ContentSecurityPolicy\Exceptions\DirectivesNormalizerException;
 use Flowpack\ContentSecurityPolicy\Exceptions\InvalidDirectiveException;
+use Flowpack\ContentSecurityPolicy\Helpers\DirectivesNormalizer;
 use Flowpack\ContentSecurityPolicy\Model\Nonce;
 use Flowpack\ContentSecurityPolicy\Model\Policy;
 use Neos\Flow\Annotations as Flow;
+use Psr\Log\LoggerInterface;
 
 /**
  * @Flow\Scope("singleton")
@@ -15,21 +18,39 @@ use Neos\Flow\Annotations as Flow;
 class PolicyFactory
 {
     /**
-     * @param string[][] $defaultDirectives
-     * @param string[][] $customDirectives
+     * @Flow\InjectConfiguration(path="throw-invalid-directive-exception")
+     */
+    protected bool $throwInvalidDirectiveException;
+
+    /**
+     * @Flow\Inject
+     */
+    protected LoggerInterface $logger;
+
+    /**
+     * @Flow\Inject
+     *
+     */
+
+    /**
+     * @param array<string, array<string|int, string|bool>> $defaultDirectives
+     * @param array<string, array<string|int, string|bool>> $customDirectives
      * @throws InvalidDirectiveException
+     * @throws DirectivesNormalizerException
      */
     public function create(Nonce $nonce, array $defaultDirectives, array $customDirectives): Policy
     {
-        $resultDirectives = $defaultDirectives;
-        foreach ($customDirectives as $key => $customDirective) {
+        $normalizedDefaultDirectives = DirectivesNormalizer::normalize($defaultDirectives, $this->logger);
+        $normalizedCustomDirectives = DirectivesNormalizer::normalize($customDirectives, $this->logger);
+
+        $resultDirectives = $normalizedDefaultDirectives;
+        foreach ($normalizedCustomDirectives as $key => $customDirective) {
             if (array_key_exists($key, $resultDirectives)) {
                 $resultDirectives[$key] = array_merge($resultDirectives[$key], $customDirective);
             } else {
                 // Custom directive is not present in default, still needs to be added.
                 $resultDirectives[$key] = $customDirective;
             }
-
             $resultDirectives[$key] = array_unique($resultDirectives[$key]);
         }
 
@@ -37,7 +58,20 @@ class PolicyFactory
         $policy->setNonce($nonce);
 
         foreach ($resultDirectives as $directive => $values) {
-            $policy->addDirective($directive, $values);
+            try {
+                $policy->addDirective($directive, $values);
+            } catch (InvalidDirectiveException $e
+            ) {
+                if ($this->throwInvalidDirectiveException) {
+                    // For development we want to make sure directives are configured correctly.
+                    throw $e;
+                } else {
+                    // In production we just log the error and continue. If a directive is invalid, we still
+                    // want to apply the rest of the policy.
+                    $this->logger->critical($e->getMessage());
+                    continue;
+                }
+            }
         }
 
         return $policy;

--- a/Classes/Helpers/DirectivesNormalizer.php
+++ b/Classes/Helpers/DirectivesNormalizer.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\ContentSecurityPolicy\Helpers;
+
+use Flowpack\ContentSecurityPolicy\Exceptions\DirectivesNormalizerException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Helper to support normalization of directives from different formats.
+ * The old format supported yaml lists. Now key-value pairs should be used for directives.
+ * In the future we will deprecate the list format!
+ *
+ * We also cleanup of empty directives and entries here before further processing.
+ */
+class DirectivesNormalizer
+{
+    /**
+     * @param array<string, array<string|int, string|bool>> $directives
+     * @return string[][]
+     * @throws DirectivesNormalizerException
+     */
+    public static function normalize(array $directives, LoggerInterface $logger): array
+    {
+        $result = [];
+        // directives e.g. script-src:
+        foreach ($directives as $directive => $values) {
+            if(is_array($values) && sizeof($values) > 0) {
+                $normalizedValues = [];
+                $firstKeyType = null;
+                // values e.g. 'self', 'unsafe-inline' OR key-value pairs e.g. example.com: true
+                foreach ($values as $key => $value) {
+                    $keyType = gettype($key);
+                    $valueType = gettype($value);
+                    if ($firstKeyType === null) {
+                        $firstKeyType = $keyType;
+                    } else {
+                        if ($keyType !== $firstKeyType) {
+                            // we do not allow mixed key types -> this should be marked as an error in the IDE as well
+                            // as Flow should throw an exception here. But just to be sure, we add this check.
+                            throw new DirectivesNormalizerException('Directives must be defined as a list OR an object.');
+                        }
+                    }
+
+                    if($keyType === 'integer' && $valueType === 'string' && !empty($value)) {
+                        // old configuration format using list
+                        $normalizedValues[] = $value;
+                        $logger->warning('Using list format for CSP directives is deprecated and will be removed in future versions. Please use key-value pairs with boolean values instead.');
+                    } elseif($keyType === 'string') {
+                        // new configuration format using key-value pairs
+                        if($valueType === 'boolean') {
+                            if($value === true && !empty($key)) {
+                                $normalizedValues[] = $key;
+                            }
+                        } else {
+                            // We chose a format similar to NodeType constraints yaml configuration.
+                            throw new DirectivesNormalizerException('When using keys in your yaml, the values must be boolean.');
+                        }
+                    }
+                }
+                if(!empty($normalizedValues)) {
+                    // we also clean up empty directives here
+                    $result[$directive] = $normalizedValues;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/Classes/Http/CspHeaderMiddleware.php
+++ b/Classes/Http/CspHeaderMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flowpack\ContentSecurityPolicy\Http;
 
 use Exception;
+use Flowpack\ContentSecurityPolicy\Exceptions\DirectivesNormalizerException;
 use Flowpack\ContentSecurityPolicy\Exceptions\InvalidDirectiveException;
 use Flowpack\ContentSecurityPolicy\Factory\PolicyFactory;
 use Flowpack\ContentSecurityPolicy\Helpers\TagHelper;
@@ -16,7 +17,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Psr\Log\LoggerInterface;
 
 class CspHeaderMiddleware implements MiddlewareInterface
 {
@@ -30,11 +30,6 @@ class CspHeaderMiddleware implements MiddlewareInterface
     /**
      * @Flow\Inject
      */
-    protected LoggerInterface $logger;
-
-    /**
-     * @Flow\Inject
-     */
     protected Nonce $nonce;
 
     /**
@@ -44,12 +39,14 @@ class CspHeaderMiddleware implements MiddlewareInterface
 
     /**
      * @Flow\InjectConfiguration(path="content-security-policy")
-     * @var string[][][]
+     * @var array<string, array<string, array<string|int, string|bool>>>
      */
     protected array $configuration;
 
     /**
      * @inheritDoc
+     * @throws InvalidDirectiveException
+     * @throws DirectivesNormalizerException
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
@@ -58,13 +55,7 @@ class CspHeaderMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        try {
-            $policy = $this->getPolicyByCurrentContext($request);
-        } catch (Exception $exception) {
-            $this->logger->critical($exception->getMessage(), ['exception' => $exception]);
-
-            return $response;
-        }
+        $policy = $this->getPolicyByCurrentContext($request);
 
         if ($policy->hasNonceDirectiveValue()) {
             $body = $response->getBody();
@@ -78,6 +69,7 @@ class CspHeaderMiddleware implements MiddlewareInterface
 
     /**
      * @throws InvalidDirectiveException
+     * @throws DirectivesNormalizerException
      */
     private function getPolicyByCurrentContext(ServerRequestInterface $request): Policy
     {
@@ -131,7 +123,7 @@ class CspHeaderMiddleware implements MiddlewareInterface
             function ($hits) use ($hitCallback) {
                 $tagMarkup = $hits[0];
                 $tagName = $hits[1];
-                
+
                 return call_user_func(
                     $hitCallback,
                     $tagMarkup,

--- a/Classes/Model/Policy.php
+++ b/Classes/Model/Policy.php
@@ -6,6 +6,7 @@ namespace Flowpack\ContentSecurityPolicy\Model;
 
 use Flowpack\ContentSecurityPolicy\Exceptions\InvalidDirectiveException;
 use Neos\Flow\Annotations as Flow;
+use Psr\Log\LoggerInterface;
 
 class Policy
 {

--- a/Configuration/Production/Settings.yaml
+++ b/Configuration/Production/Settings.yaml
@@ -1,0 +1,3 @@
+Flowpack:
+  ContentSecurityPolicy:
+    throw-invalid-directive-exception: false

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,69 +2,70 @@ Flowpack:
   ContentSecurityPolicy:
     enabled: true
     report-only: false
+    throw-invalid-directive-exception: true
     content-security-policy:
       default:
         base-uri:
-          - 'self'
+         'self': true
         connect-src:
-          - 'self'
+          'self': true
         default-src:
-          - 'self'
+          'self': true
         form-action:
-          - 'self'
+          'self': true
         img-src:
-          - 'self'
+          'self': true
         media-src:
-          - 'self'
+          'self': true
         frame-src:
-          - 'self'
+          'self': true
         object-src:
-          - 'self'
+          'self': true
         script-src:
-          - 'self'
+          'self': true
         style-src:
-          - 'self'
+          'self': true
         style-src-attr:
-          - 'self'
+          'self': true
         style-src-elem:
-          - 'self'
+          'self': true
         font-src:
-          - 'self'
+          'self': true
       custom: [ ]
       backend:
         base-uri:
-          - 'self'
+          'self': true
         connect-src:
-          - 'self'
+          'self': true
         default-src:
-          - 'self'
+          'self': true
         form-action:
-          - 'self'
+          'self': true
         img-src:
-          - 'self'
-          - 'data:'
+          'self': true
+          'data:': true
         media-src:
-          - 'self'
+          'self': true
         frame-src:
-          - 'self'
+          'self': true
         object-src:
-          - 'self'
+          'self': true
         script-src:
-          - 'self'
-          - 'unsafe-inline'
-          - 'unsafe-eval'
+          'self': true
+          'unsafe-inline': true
+          'unsafe-eval': true
         style-src:
-          - 'self'
-          - 'unsafe-inline'
+          'self': true
+          'unsafe-inline': true
         style-src-attr:
-          - 'self'
-          - 'unsafe-inline'
+          'self': true
+          'unsafe-inline': true
         style-src-elem:
-          - 'self'
-          - 'unsafe-inline'
+          'self': true
+          'unsafe-inline': true
         font-src:
-          - 'self'
-          - 'data:'
+          'self': true
+          'data:': true
       custom-backend: [ ]
 
 Neos:

--- a/README.md
+++ b/README.md
@@ -39,36 +39,54 @@ Flowpack:
     content-security-policy:
       default:
         base-uri:
-          - 'self'
+          'self': true
         connect-src:
-          - 'self'
+          'self': true
         default-src:
-          - 'self'
+          'self': true
         form-action:
-          - 'self'
+          'self': true
         img-src:
-          - 'self'
+          'self': true
         media-src:
-          - 'self'
+          'self': true
         frame-src:
-          - 'self'
+          'self': true
         object-src:
-          - 'self'
+          'self': true
         script-src:
-          - 'self'
+          'self': true
         style-src:
-          - 'self'
+          'self': true
         style-src-attr:
-          - 'self'
+          'self': true
         style-src-elem:
-          - 'self'
+          'self': true
         font-src:
-          - 'self'
+          'self': true
       custom: [ ]
 ```
 
 Now only resources from the same origin are allowed for the most common directives.
 It is enabled by default and the report-only mode is disabled.
+
+## Deprecated Configuration
+
+Make sure to change any old configuration to the new object format. **Support for the old list format will be removed in future versions.**
+
+The new config allows to merge configurations from different packages/yaml files.
+
+```yaml
+frame-src:
+    # Deprecated list format
+    # - 'https://www.youtube.com':
+    # - 'https://staticxx.facebook.com':
+    
+    # New object format
+    'https://www.youtube.com': true
+    'https://staticxx.facebook.com': true
+```
+
 
 ## Custom directives and values
 
@@ -84,8 +102,8 @@ Flowpack:
     content-security-policy:
       custom:
         frame-src:
-          - 'https://www.youtube.com'
-          - 'https://staticxx.facebook.com'
+          'https://www.youtube.com': true
+          'https://staticxx.facebook.com': true
 ```
 
 If you fully want to override the entire default config then just override the default key in yaml.
@@ -112,7 +130,7 @@ Flowpack:
     content-security-policy:
       custom:
         script-src:
-          - '{nonce}'
+          '{nonce}': true
 ```
 
 Now the header will include a `nonce-automatedgeneratedrandomstring` in the script-src directive.
@@ -133,38 +151,38 @@ Flowpack:
     content-security-policy:
       backend:
         base-uri:
-          - 'self'
+          'self': true
         connect-src:
-          - 'self'
+          'self': true
         default-src:
-          - 'self'
+          'self': true
         form-action:
-          - 'self'
+          'self': true
         img-src:
-          - 'self'
-          - 'data:'
+          'self': true
+          'data:': true
         media-src:
-          - 'self'
+          'self': true
         frame-src:
-          - 'self'
+          'self': true
         object-src:
-          - 'self'
+          'self': true
         script-src:
-          - 'self'
-          - 'unsafe-inline'
-          - 'unsafe-eval'
+          'self': true
+          'unsafe-inline': true
+          'unsafe-eval': true
         style-src:
-          - 'self'
-          - 'unsafe-inline'
+          'self': true
+          'unsafe-inline': true
         style-src-attr:
-          - 'self'
-          - 'unsafe-inline'
+          'self': true
+          'unsafe-inline': true
         style-src-elem:
-          - 'self'
-          - 'unsafe-inline'
+          'self': true
+          'unsafe-inline': true
         font-src:
-          - 'self'
-          - 'data:'
+          'self': true
+          'data:': true
       custom-backend: [ ]
 ```
 

--- a/Tests/Unit/Factory/PolicyFactoryTest.php
+++ b/Tests/Unit/Factory/PolicyFactoryTest.php
@@ -11,7 +11,10 @@ use Flowpack\ContentSecurityPolicy\Model\Nonce;
 use Flowpack\ContentSecurityPolicy\Model\Policy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
 
 #[CoversClass(PolicyFactory::class)]
 #[UsesClass(Policy::class)]
@@ -19,9 +22,24 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(InvalidDirectiveException::class)]
 class PolicyFactoryTest extends TestCase
 {
+    private readonly LoggerInterface&MockObject $loggerMock;
+    private readonly PolicyFactory $policyFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+
+        $this->policyFactory = new PolicyFactory();
+
+        $this->policyFactoryReflection = new ReflectionClass($this->policyFactory);
+        $this->policyFactoryReflection->getProperty('logger')->setValue($this->policyFactory, $this->loggerMock);
+        $this->policyFactoryReflection->getProperty('throwInvalidDirectiveException')->setValue($this->policyFactory, true);
+    }
+
     public function testCreateShouldReturnPolicyAndMergeCustomWithDefaultDirective(): void
     {
-        $policyFactory = new PolicyFactory();
         $nonceMock = $this->createMock(Nonce::class);
 
         $defaultDirective = [
@@ -48,14 +66,13 @@ class PolicyFactoryTest extends TestCase
             ],
         ];
 
-        $result = $policyFactory->create($nonceMock, $defaultDirective, $customDirective);
+        $result = $this->policyFactory->create($nonceMock, $defaultDirective, $customDirective);
 
         self::assertSame($expected, $result->getDirectives());
     }
 
     public function testCreateShouldReturnPolicyAndHandleSpecialDirectives(): void
     {
-        $policyFactory = new PolicyFactory();
         $nonceMock = $this->createMock(Nonce::class);
 
         $defaultDirective = [
@@ -73,14 +90,13 @@ class PolicyFactoryTest extends TestCase
             ],
         ];
 
-        $result = $policyFactory->create($nonceMock, $defaultDirective, $customDirective);
+        $result = $this->policyFactory->create($nonceMock, $defaultDirective, $customDirective);
 
         self::assertSame($expected, $result->getDirectives());
     }
 
     public function testCreateShouldFailWithInvalidDirective(): void
     {
-        $policyFactory = new PolicyFactory();
         $nonceMock = $this->createMock(Nonce::class);
 
         $defaultDirective = [
@@ -94,12 +110,32 @@ class PolicyFactoryTest extends TestCase
         $customDirective = [];
 
         $this->expectException(InvalidDirectiveException::class);
-        $policyFactory->create($nonceMock, $defaultDirective, $customDirective);
+        $this->policyFactory->create($nonceMock, $defaultDirective, $customDirective);
+    }
+
+    public function testCreateShouldLogInvalidDirectiveInProduction(): void
+    {
+        $nonceMock = $this->createMock(Nonce::class);
+        $this->policyFactoryReflection->getProperty('throwInvalidDirectiveException')->setValue($this->policyFactory, false);
+
+        $defaultDirective = [
+            'invalid' => [
+                'self',
+            ],
+            'script-src' => [
+                'self',
+            ],
+        ];
+        $customDirective = [];
+
+        $this->loggerMock->expects($this->once())->method('critical');
+        $this->policyFactory->create($nonceMock, $defaultDirective, $customDirective);
+
+        $this->policyFactoryReflection->getProperty('throwInvalidDirectiveException')->setValue($this->policyFactory, true);
     }
 
     public function testCreateShouldReturnPolicyWithUniqueValues(): void
     {
-        $policyFactory = new PolicyFactory();
         $nonceMock = $this->createMock(Nonce::class);
 
         $defaultDirective = [
@@ -129,14 +165,13 @@ class PolicyFactoryTest extends TestCase
             ],
         ];
 
-        $result = $policyFactory->create($nonceMock, $defaultDirective, $customDirective);
+        $result = $this->policyFactory->create($nonceMock, $defaultDirective, $customDirective);
 
         self::assertSame($expected, $result->getDirectives());
     }
 
     public function testCreateShouldAddDirectiveWhichIsPresentInCustomButNotDefaultConfiguration(): void
     {
-        $policyFactory = new PolicyFactory();
         $nonceMock = $this->createMock(Nonce::class);
 
         $defaultDirective = [
@@ -165,7 +200,7 @@ class PolicyFactoryTest extends TestCase
             ],
         ];
 
-        $result = $policyFactory->create($nonceMock, $defaultDirective, $customDirective);
+        $result = $this->policyFactory->create($nonceMock, $defaultDirective, $customDirective);
 
         self::assertSame($expected, $result->getDirectives());
     }

--- a/Tests/Unit/Helpers/DirectivesNormalizerTest.php
+++ b/Tests/Unit/Helpers/DirectivesNormalizerTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Helpers;
+
+use Flowpack\ContentSecurityPolicy\Exceptions\DirectivesNormalizerException;
+use Flowpack\ContentSecurityPolicy\Helpers\DirectivesNormalizer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+#[CoversClass(DirectivesNormalizer::class)]
+class DirectivesNormalizerTest extends TestCase
+{
+    private readonly LoggerInterface&MockObject $loggerMock;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+    }
+
+    public function testDeprecatedConfiguration(): void
+    {
+        // deprecated list configuration should still work but log deprecation warnings
+        $this->loggerMock->expects($this->atLeast(4))->method('warning');
+
+        $actual = DirectivesNormalizer::normalize([
+            'base-uri' => [
+                'test.com',
+            ],
+            'script-src' => [
+                'self',
+                'unsafe-inline',
+                'example.com',
+                'another-example.com',
+            ],
+        ], $this->loggerMock);
+        $expected = [
+            'base-uri' => [
+                'test.com',
+            ],
+            'script-src' => [
+                'self',
+                'unsafe-inline',
+                'example.com',
+                'another-example.com',
+            ],
+        ];
+        self::assertSame($expected, $actual);
+
+        // empty directives should be removed
+        $actual = DirectivesNormalizer::normalize([
+            'base-uri' => [],
+            'script-src' => [
+                'self',
+                'unsafe-inline',
+                'example.com',
+                'another-example.com',
+            ],
+        ], $this->loggerMock);
+        $expected = [
+            'script-src' => [
+                'self',
+                'unsafe-inline',
+                'example.com',
+                'another-example.com',
+            ],
+        ];
+        self::assertSame($expected, $actual);
+
+        // empty directive entries should be removed
+        // empty directives should be removed
+        $actual = DirectivesNormalizer::normalize([
+            'base-uri' => [
+                '',
+            ],
+            'script-src' => [
+                'self',
+                'unsafe-inline',
+                'example.com',
+                'another-example.com',
+            ],
+        ], $this->loggerMock);
+        $expected = [
+            'script-src' => [
+                'self',
+                'unsafe-inline',
+                'example.com',
+                'another-example.com',
+            ],
+        ];
+        self::assertSame($expected, $actual);
+
+        // empty directives should be removed
+        $actual = DirectivesNormalizer::normalize([
+            'base-uri' => [],
+            'script-src' => [],
+        ], $this->loggerMock);
+        $expected = [];
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function testConfiguration(): void
+    {
+        $actual = DirectivesNormalizer::normalize([
+            'base-uri' => [
+                'test.com' => true,
+            ],
+            'script-src' => [
+                'self' => true,
+                'unsafe-inline' => true,
+                'example.com' => true,
+                'another-example.com' => true,
+            ],
+        ], $this->loggerMock);
+        $expected = [
+            'base-uri' => [
+                'test.com',
+            ],
+            'script-src' => [
+                'self',
+                'unsafe-inline',
+                'example.com',
+                'another-example.com',
+            ],
+        ];
+        self::assertSame($expected, $actual);
+
+        // empty directive entries should be removed
+        // empty directives should be removed
+        $actual = DirectivesNormalizer::normalize([
+            'base-uri' => [
+                '' => true,
+            ],
+            'script-src' => [
+                'self' => true,
+                'unsafe-inline' => true,
+                'example.com' => true,
+                'another-example.com' => true,
+            ],
+        ], $this->loggerMock);
+        $expected = [
+            'script-src' => [
+                'self',
+                'unsafe-inline',
+                'example.com',
+                'another-example.com',
+            ],
+        ];
+        self::assertSame($expected, $actual);
+
+        $actual = DirectivesNormalizer::normalize([
+            'base-uri' => [],
+            'script-src' => [],
+        ], $this->loggerMock);
+        $expected = [
+        ];
+        self::assertSame($expected, $actual);
+
+        $actual = DirectivesNormalizer::normalize([
+            'base-uri' => null,
+            'script-src' => [],
+        ], $this->loggerMock);
+
+        self::assertSame($expected, $actual);
+
+        $actual = DirectivesNormalizer::normalize([
+            'base-uri',
+            'script-src' => [],
+        ], $this->loggerMock);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function testConfigurationWithDirectivesUsingFalse(): void
+    {
+        $actual = DirectivesNormalizer::normalize([
+            'base-uri' => [
+                'test.com' => true,
+                'another-example.com' => false,
+            ],
+            'script-src' => [
+                'self' => true,
+                'unsafe-inline' => false,
+                'example.com' => true,
+                'another-example.com' => false,
+            ],
+        ], $this->loggerMock);
+        $expected = [
+            'base-uri' => [
+                'test.com',
+            ],
+            'script-src' => [
+                'self',
+                'example.com',
+            ],
+        ];
+        self::assertSame($expected, $actual);
+    }
+
+    public function testInvalidDirectiveExceptionForMixedConfig(): void
+    {
+        $this->expectException(DirectivesNormalizerException::class);
+        $this->expectExceptionMessageMatches("/must be defined as a list OR an object/");
+        DirectivesNormalizer::normalize([
+            'script-src' => [
+                'self' => true,
+                'unsafe-inline' => true,
+                'example.com',
+                'another-example.com' => true,
+            ],
+        ], $this->loggerMock);
+    }
+
+    public function testInvalidDirectiveExceptionForWrongKeyValue(): void
+    {
+        $this->expectException(DirectivesNormalizerException::class);
+        $this->expectExceptionMessageMatches("/the values must be boolean/");
+        DirectivesNormalizer::normalize([
+            'script-src' => [
+                'self' => true,
+                'unsafe-inline' => 'foo bar',
+                'example.com' => true,
+                'another-example.com' => true,
+            ],
+        ], $this->loggerMock);
+    }
+}

--- a/Tests/Unit/Http/CspHeaderMiddlewareTest.php
+++ b/Tests/Unit/Http/CspHeaderMiddlewareTest.php
@@ -9,7 +9,6 @@ use Flowpack\ContentSecurityPolicy\Helpers\TagHelper;
 use Flowpack\ContentSecurityPolicy\Http\CspHeaderMiddleware;
 use Flowpack\ContentSecurityPolicy\Model\Nonce;
 use Flowpack\ContentSecurityPolicy\Model\Policy;
-use Neos\Flow\Security\Exception\InvalidPolicyException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -18,7 +17,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use Throwable;
 
@@ -33,7 +31,6 @@ class CspHeaderMiddlewareTest extends TestCase
     private readonly ServerRequestInterface&MockObject $requestMock;
     private readonly RequestHandlerInterface&MockObject $requestHandlerMock;
     private readonly ResponseInterface&MockObject $responseMock;
-    private readonly LoggerInterface&MockObject $loggerMock;
     private readonly UriInterface&MockObject $uriMock;
     private readonly PolicyFactory&MockObject $policyFactoryMock;
     private readonly Policy&MockObject $policyMock;
@@ -50,16 +47,12 @@ class CspHeaderMiddlewareTest extends TestCase
         $this->requestMock = $this->createMock(ServerRequestInterface::class);
         $this->requestHandlerMock = $this->createMock(RequestHandlerInterface::class);
         $this->responseMock = $this->createMock(ResponseInterface::class);
-        $this->loggerMock = $this->createMock(LoggerInterface::class);
         $nonceMock = $this->createMock(Nonce::class);
         $this->uriMock = $this->createMock(UriInterface::class);
         $this->policyFactoryMock = $this->createMock(PolicyFactory::class);
         $this->policyMock = $this->createMock(Policy::class);
 
         $this->middlewareReflection = new ReflectionClass($this->middleware);
-
-        $reflectionProperty = $this->middlewareReflection->getProperty('logger');
-        $reflectionProperty->setValue($this->middleware, $this->loggerMock);
 
         $reflectionProperty = $this->middlewareReflection->getProperty('enabled');
         $reflectionProperty->setValue($this->middleware, true);
@@ -83,22 +76,6 @@ class CspHeaderMiddlewareTest extends TestCase
     {
         $reflectionProperty = $this->middlewareReflection->getProperty('enabled');
         $reflectionProperty->setValue($this->middleware, false);
-
-        $this->responseMock->expects($this->never())->method('withAddedHeader');
-
-        $this->middleware->process($this->requestMock, $this->requestHandlerMock);
-    }
-
-    public function testProcessShouldDoNothingIfPolicyIsInvalid(): void
-    {
-        $this->requestMock->expects($this->once())->method('getUri')->willReturn($this->uriMock);
-        $this->uriMock->expects($this->once())->method('getPath')->willReturn('/');
-
-        $this->policyFactoryMock->expects($this->once())->method('create')->willThrowException(
-            new InvalidPolicyException()
-        );
-
-        $this->loggerMock->expects($this->once())->method('critical');
 
         $this->responseMock->expects($this->never())->method('withAddedHeader');
 

--- a/Tests/Unit/Model/PolicyTest.php
+++ b/Tests/Unit/Model/PolicyTest.php
@@ -11,6 +11,7 @@ use Flowpack\ContentSecurityPolicy\Model\Policy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use ReflectionClass;
 
 #[CoversClass(Policy::class)]
@@ -25,12 +26,16 @@ class PolicyTest extends TestCase
     {
         parent::setUp();
 
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+
         $this->policy = new Policy();
-        $nonceMock = $this->createMock(Nonce::class);
-        $this->policy->setNonce($nonceMock);
 
         $this->policyReflection = new ReflectionClass($this->policy);
+
         $this->policyReflection->getProperty('reportOnly')->setValue($this->policy, false);
+
+        $nonceMock = $this->createMock(Nonce::class);
+        $this->policy->setNonce($nonceMock);
     }
 
     public function testGetSecurityHeaderKeyWithReportOnlyEnabled(): void


### PR DESCRIPTION
* added DirectivesNormalizer to support new and old config
  * new config structure `'https://example.com': true`
  * old config structure `- 'https://example.com'`
  * adds some more cleanup of config (empty directives, empty rules)
* log deprecation warnings when old config is used
* throw exceptions when mixing old an new config in one directive
* only throw InvalidDirectiveException in production so other CSP rules are still applied

Fixes #9 
Fixes #10 
